### PR TITLE
Support non-period separated Addresses when unmarshaling.

### DIFF
--- a/address.go
+++ b/address.go
@@ -15,6 +15,7 @@
 package insteon
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -33,16 +34,23 @@ func (a Address) String() string { return sprintf("%02x.%02x.%02x", a[0], a[1], 
 // Insteon address. If the address cannot be parsed then
 // UnmarshalText returns an ErrAddressFormat error
 func (a *Address) UnmarshalText(text []byte) error {
+
+	// Support non-period separated input too.
+	if len(text) == 6 {
+		text = bytes.Join([][]byte{text[0:2], text[2:4], text[4:6]}, []byte("."))
+	}
+	if len(text) != 8 {
+		return ErrAddrFormat
+	}
 	var b1, b2, b3 byte
 	_, err := fmt.Sscanf(string(text), "%2x.%2x.%2x", &b1, &b2, &b3)
-	if err == nil {
-		a[0] = b1
-		a[1] = b2
-		a[2] = b3
-	} else {
-		err = ErrAddrFormat
+	if err != nil {
+		return ErrAddrFormat
 	}
-	return err
+	a[0] = b1
+	a[1] = b2
+	a[2] = b3
+	return nil
 }
 
 // MarshalJSON will convert the address to a JSON string

--- a/address_test.go
+++ b/address_test.go
@@ -19,24 +19,44 @@ import "testing"
 func TestAddressUnmarshalText(t *testing.T) {
 	tests := []struct {
 		input   string
-		correct bool
+		want    Address
+		wantErr bool
 	}{
-		{"01.02.03", true},
-		{"abcd", false},
-		{"01b.02.03", false},
+		{"01.02.03", Address{1, 2, 3}, false},
+		{"a1.b2.c3", Address{0xA1, 0xB2, 0xC3}, false},
+		{"D1.E2.F3", Address{0xD1, 0xE2, 0xF3}, false},
+		{"a1b2c3", Address{0xA1, 0xB2, 0xC3}, false},
+		{"D1E2F3", Address{0xD1, 0xE2, 0xF3}, false},
+		{"abcd", Address{}, true},
+		{"abcdefg", Address{}, true},
+		{"01b.02.03", Address{}, true},
 	}
 
 	for i, test := range tests {
 		address := Address{}
 		err := address.UnmarshalText([]byte(test.input))
-		if err == nil && !test.correct {
+		if test.wantErr && err == nil {
 			t.Errorf("tests[%d] expected failure", i)
-		} else if err != nil && test.correct {
+		} else if !test.wantErr && err != nil {
 			t.Errorf("tests[%d] failed: %v", i, err)
 		}
+		if test.want != address {
+			t.Errorf("tests[%d] expected %q got %q", i, test.input, test.want)
+		}
+	}
+}
 
-		if test.correct && test.input != address.String() {
-			t.Errorf("tests[%d] expected %q got %q", i, test.input, address.String())
+func TestAddressString(t *testing.T) {
+	tests := []struct {
+		input Address
+		want  string
+	}{
+		{Address{0, 1, 2}, "00.01.02"},
+	}
+	for i, test := range tests {
+		got := test.input.String()
+		if got != test.want {
+			t.Errorf("tests[%d] %q.String(): expected %q got %q", i, test.input, test.want, got)
 		}
 	}
 }


### PR DESCRIPTION
Also, split out Address.String() tests.
Expand unmarshaling tests.  (Uppercase hex too!)