### PR TITLE
Parallelize tests.

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestAddressUnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input   string
 		want    Address
@@ -52,6 +53,7 @@ func TestAddressUnmarshalText(t *testing.T) {
 }
 
 func TestAddressString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input Address
 		want  string
@@ -69,6 +71,7 @@ func TestAddressString(t *testing.T) {
 }
 
 func TestAddressMarshaling(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input           string
 		expectedAddress Address

--- a/address_test.go
+++ b/address_test.go
@@ -38,6 +38,7 @@ func TestAddressUnmarshalText(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
 			address := Address{}
 			err := address.UnmarshalText([]byte(test.input))
 			if test.wantErr && err == nil {
@@ -62,6 +63,7 @@ func TestAddressString(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.input), func(t *testing.T) {
+			t.Parallel()
 			got := test.input.String()
 			if got != test.want {
 				t.Errorf("%q.String(): got %q, want %q", test.input, got, test.want)
@@ -84,6 +86,7 @@ func TestAddressMarshaling(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
 			var address Address
 			err := address.UnmarshalJSON([]byte(test.input))
 			if err == nil {

--- a/command_test.go
+++ b/command_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestCommandSubCommand(t *testing.T) {
+	t.Parallel()
 	cmd := Command{0x00, 0x01, 0x02}
 	cmd = cmd.SubCommand(3)
 	if cmd[2] != 3 {
@@ -33,6 +34,7 @@ func TestCommandSubCommand(t *testing.T) {
 }
 
 func TestCommandString(t *testing.T) {
+	t.Parallel()
 	fs := token.NewFileSet()
 	parsedFile, err := parser.ParseFile(fs, "commands.go", nil, parser.ParseComments)
 	if err == nil {

--- a/connection_test.go
+++ b/connection_test.go
@@ -28,6 +28,7 @@ func newTestConnection(dst Address) (*connection, chan *MessageRequest, chan *Me
 // TODO need to rewrite this test because it sucks and is full
 // of race conditions
 func TestConnectionProcess(t *testing.T) {
+	t.Parallel()
 	doneCh := make(chan *MessageRequest, 1)
 	recvCh := make(chan *Message, 1)
 	upstreamRecvCh := make(chan *Message, 1)
@@ -57,6 +58,7 @@ func TestConnectionProcess(t *testing.T) {
 }
 
 func TestConnectionReceiveAck(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc        string
 		version     EngineVersion
@@ -96,6 +98,7 @@ func TestConnectionReceiveAck(t *testing.T) {
 }
 
 func TestConnectionReceiveMatch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    *Message
 		match    Command
@@ -123,6 +126,7 @@ func TestConnectionReceiveMatch(t *testing.T) {
 }
 
 func TestConnectionReceive(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    *Message
 		expected int
@@ -145,6 +149,7 @@ func TestConnectionReceive(t *testing.T) {
 }
 
 func TestConnectionSend(t *testing.T) {
+	t.Parallel()
 	upstreamSendCh := make(chan *MessageRequest, 1)
 	conn := &connection{
 		addr:           testDstAddr,

--- a/connection_test.go
+++ b/connection_test.go
@@ -79,6 +79,7 @@ func TestConnectionReceiveAck(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			conn := &connection{
 				addr:    testDstAddr,
 				version: test.version,

--- a/database_test.go
+++ b/database_test.go
@@ -33,6 +33,7 @@ func TestDeviceInfoComplete(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%+v %+v", test.input.DevCat, test.input.FirmwareVersion), func(t *testing.T) {
+			t.Parallel()
 			if test.input.Complete() != test.expected {
 				t.Errorf("got %v, want %v ", test.input.Complete(), test.expected)
 			}
@@ -90,6 +91,7 @@ func TestProductDatabaseUpdateFind(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			pdb := NewProductDB().(*productDatabase)
 			if _, found := pdb.Find(address); found {
 				t.Error("got found, want not found ")

--- a/database_test.go
+++ b/database_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestDeviceInfoComplete(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    DeviceInfo
 		expected bool
@@ -75,6 +76,7 @@ func (tpd *testProductDB) Find(address Address) (deviceInfo DeviceInfo, found bo
 }
 
 func TestProductDatabaseUpdateFind(t *testing.T) {
+	t.Parallel()
 	address := Address{0, 1, 2}
 	tests := []struct {
 		desc   string

--- a/device_test.go
+++ b/device_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestDeviceRegistry(t *testing.T) {
+	t.Parallel()
 	dr := &DeviceRegistry{}
 
 	if _, found := dr.Find(Category(1)); found {

--- a/error_test.go
+++ b/error_test.go
@@ -33,6 +33,7 @@ func TestBufError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			if test.input.Error() != test.expected {
 				t.Errorf("got %v expected %v", test.input.Error(), test.expected)
 			}
@@ -70,6 +71,7 @@ func TestIsError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			if isError(test.cause, test.check) != test.expected {
 				switch e := test.cause.(type) {
 				case *traceError:

--- a/error_test.go
+++ b/error_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestBufError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc     string
 		input    error
@@ -40,6 +41,7 @@ func TestBufError(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
+	t.Parallel()
 	err := &traceError{
 		Cause: errors.New("Foo"),
 		Frame: runtime.Frame{File: "/foo/bar/run.go", Line: 10, Function: "Woops"},
@@ -51,6 +53,7 @@ func TestError(t *testing.T) {
 }
 
 func TestIsError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc     string
 		cause    error
@@ -81,6 +84,7 @@ func TestIsError(t *testing.T) {
 }
 
 func TestTraceError(t *testing.T) {
+	t.Parallel()
 	err := newTraceError(ErrBufferTooShort)
 	if _, ok := err.(*traceError); !ok {
 		t.Errorf("expected *Error got %T", err)

--- a/i1device_test.go
+++ b/i1device_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestI1DeviceIsDevice(t *testing.T) {
+	t.Parallel()
 	var device interface{}
 	device = &I1Device{}
 
@@ -15,6 +16,7 @@ func TestI1DeviceIsDevice(t *testing.T) {
 }
 
 func TestI1DeviceSend(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc          string
 		payload       []byte
@@ -49,6 +51,7 @@ func TestI1DeviceSend(t *testing.T) {
 }
 
 func TestI1DeviceReceive(t *testing.T) {
+	t.Parallel()
 	// This test is flaky about 15% of the time.
 	recvCh := make(chan *Message, 1)
 	requestRecvCh := make(chan *CommandResponse, 1)
@@ -75,6 +78,7 @@ func TestI1DeviceReceive(t *testing.T) {
 }
 
 func TestI1DeviceReceiveAck(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc           string
 		input          *MessageRequest
@@ -136,6 +140,7 @@ func TestI1DeviceReceiveAck(t *testing.T) {
 }
 
 func TestI1DeviceDoneCh(t *testing.T) {
+	t.Parallel()
 	doneCh := make(chan *CommandResponse, 1)
 	requestDoneCh := make(chan *CommandRequest, 1)
 	requestRecvCh := make(chan *CommandResponse, 1)
@@ -166,6 +171,7 @@ func TestI1DeviceDoneCh(t *testing.T) {
 }
 
 func TestI1DeviceWaitRequestTimeout(t *testing.T) {
+	t.Parallel()
 	recvCh := make(chan *Message, 1)
 	doneCh := make(chan *CommandResponse, 1)
 	requestDoneCh := make(chan *CommandRequest, 1)
@@ -194,6 +200,7 @@ func TestI1DeviceWaitRequestTimeout(t *testing.T) {
 }
 
 func TestI1DeviceQueueTimeout(t *testing.T) {
+	t.Parallel()
 	recvCh := make(chan *Message, 1)
 	doneCh := make(chan *CommandResponse, 1)
 	requestDoneCh := make(chan *CommandRequest, 1)
@@ -218,6 +225,7 @@ func TestI1DeviceQueueTimeout(t *testing.T) {
 }
 
 func TestI1DeviceAddress(t *testing.T) {
+	t.Parallel()
 	expected := Address{3, 4, 5}
 	device := &I1Device{address: expected}
 	if device.Address() != expected {
@@ -226,6 +234,7 @@ func TestI1DeviceAddress(t *testing.T) {
 }
 
 func TestI1DeviceCommands(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc        string
 		callback    func(*I1Device) error
@@ -271,6 +280,7 @@ func TestI1DeviceCommands(t *testing.T) {
 }
 
 func TestI1DeviceProductData(t *testing.T) {
+	t.Parallel()
 	sendCh := make(chan *CommandRequest, 1)
 	device := &I1Device{
 		sendCh: sendCh,
@@ -294,6 +304,7 @@ func TestI1DeviceProductData(t *testing.T) {
 }
 
 func TestI1DeviceBlockDataTransfer(t *testing.T) {
+	t.Parallel()
 	device := &I1Device{}
 	_, err := device.BlockDataTransfer(0, 0, 0)
 	if err != ErrNotImplemented {
@@ -302,6 +313,7 @@ func TestI1DeviceBlockDataTransfer(t *testing.T) {
 }
 
 func TestI1DeviceString(t *testing.T) {
+	t.Parallel()
 	device := &I1Device{address: Address{3, 4, 5}}
 	expected := "I1 Device (03.04.05)"
 	if device.String() != expected {

--- a/i1device_test.go
+++ b/i1device_test.go
@@ -28,6 +28,7 @@ func TestI1DeviceSend(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *CommandRequest, 1)
 			upstreamSendCh := make(chan *MessageRequest, 1)
 			device := &I1Device{
@@ -92,6 +93,7 @@ func TestI1DeviceReceiveAck(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			recvCh := make(chan *Message, 1)
 			doneCh := make(chan *MessageRequest, 1)
 			requestDoneCh := make(chan *CommandRequest, 1)
@@ -251,6 +253,7 @@ func TestI1DeviceCommands(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *CommandRequest, 1)
 			device := &I1Device{
 				sendCh: sendCh,

--- a/i2csdevice_test.go
+++ b/i2csdevice_test.go
@@ -29,6 +29,7 @@ func TestI2CsDeviceCommands(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *CommandRequest, 1)
 			device := &I2CsDevice{&I2Device{&I1Device{sendCh: sendCh}}}
 

--- a/i2csdevice_test.go
+++ b/i2csdevice_test.go
@@ -17,6 +17,7 @@ package insteon
 import "testing"
 
 func TestI2CsDeviceCommands(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc        string
 		callback    func(*I2CsDevice) error
@@ -55,6 +56,7 @@ func TestI2CsDeviceCommands(t *testing.T) {
 }
 
 func TestI2CsSendCommand(t *testing.T) {
+	t.Parallel()
 	sendCh := make(chan *CommandRequest, 1)
 	device := &I2CsDevice{&I2Device{&I1Device{sendCh: sendCh}}}
 	go func() {
@@ -69,6 +71,7 @@ func TestI2CsSendCommand(t *testing.T) {
 }
 
 func TestI2CsDeviceString(t *testing.T) {
+	t.Parallel()
 	device := &I2CsDevice{&I2Device{&I1Device{address: Address{3, 4, 5}}}}
 	expected := "I2CS Device (03.04.05)"
 	if device.String() != expected {

--- a/i2device_test.go
+++ b/i2device_test.go
@@ -44,6 +44,7 @@ func TestI2DeviceCommands(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *CommandRequest, 1)
 			device := &I2Device{&I1Device{sendCh: sendCh}}
 

--- a/i2device_test.go
+++ b/i2device_test.go
@@ -17,6 +17,7 @@ package insteon
 import "testing"
 
 func TestI2DeviceIsLinkable(t *testing.T) {
+	t.Parallel()
 	device := Device(&I2Device{})
 	linkable := device.(LinkableDevice)
 	if linkable == nil {
@@ -25,6 +26,7 @@ func TestI2DeviceIsLinkable(t *testing.T) {
 }
 
 func TestI2DeviceCommands(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc        string
 		callback    func(*I2Device) error
@@ -69,6 +71,7 @@ func TestI2DeviceCommands(t *testing.T) {
 }
 
 func TestI2DeviceLinks(t *testing.T) {
+	t.Parallel()
 	sendCh := make(chan *CommandRequest, 1)
 	device := &I2Device{&I1Device{sendCh: sendCh}}
 
@@ -91,6 +94,7 @@ func TestI2DeviceLinks(t *testing.T) {
 }
 
 func TestI2DeviceString(t *testing.T) {
+	t.Parallel()
 	device := &I2Device{&I1Device{address: Address{3, 4, 5}}}
 	expected := "I2 Device (03.04.05)"
 	if device.String() != expected {

--- a/insteon_test.go
+++ b/insteon_test.go
@@ -44,6 +44,7 @@ func TestAddress(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.input), func(t *testing.T) {
+			t.Parallel()
 			address := Address(test.input)
 
 			if address.String() != test.str {
@@ -64,6 +65,7 @@ func TestProductKey(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.input), func(t *testing.T) {
+			t.Parallel()
 			key := ProductKey(test.input)
 			if key.String() != test.expectedString {
 				t.Errorf("got ProductKey %q, want %q", key.String(), test.expectedString)
@@ -85,6 +87,7 @@ func TestDevCat(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.input), func(t *testing.T) {
+			t.Parallel()
 			devCat := DevCat(test.input)
 			if devCat.Category() != test.expectedCategory {
 				t.Errorf("got Category 0x%02x, want 0x%02x", devCat.Category(), test.expectedCategory)
@@ -115,6 +118,7 @@ func TestDevCatMarshaling(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.input), func(t *testing.T) {
+			t.Parallel()
 			var devCat DevCat
 			err := devCat.UnmarshalJSON([]byte(test.input))
 			if err == nil {
@@ -148,6 +152,7 @@ func TestProductDataMarshaling(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			pd := &ProductData{}
 			err := pd.UnmarshalBinary(test.input)
 			if !isError(err, test.expectedError) {

--- a/insteon_test.go
+++ b/insteon_test.go
@@ -26,6 +26,7 @@ func init() {
 }
 
 func TestFirmwareVersionString(t *testing.T) {
+	t.Parallel()
 	ver := FirmwareVersion(0x42)
 	if ver.String() != "0x42" {
 		t.Errorf("expected %q got %q", "0x42", ver.String())
@@ -33,6 +34,7 @@ func TestFirmwareVersionString(t *testing.T) {
 }
 
 func TestAddress(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input [3]byte
 		str   string
@@ -52,6 +54,7 @@ func TestAddress(t *testing.T) {
 }
 
 func TestProductKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input          [3]byte
 		expectedString string
@@ -70,6 +73,7 @@ func TestProductKey(t *testing.T) {
 }
 
 func TestDevCat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input               [2]byte
 		expectedCategory    Category
@@ -98,6 +102,7 @@ func TestDevCat(t *testing.T) {
 }
 
 func TestDevCatMarshaling(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input          string
 		expectedDevCat DevCat
@@ -129,6 +134,7 @@ func TestDevCatMarshaling(t *testing.T) {
 }
 
 func TestProductDataMarshaling(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc           string
 		input          []byte

--- a/lighting_test.go
+++ b/lighting_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestSwitchConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input             []byte
 		expectedErr       error
@@ -43,6 +44,7 @@ func TestSwitchConfig(t *testing.T) {
 }
 
 func TestDimmerConfig(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input             []byte
 		expectedErr       error
@@ -91,6 +93,7 @@ func TestDimmerConfig(t *testing.T) {
 }
 
 func TestLightFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    LightFlags
 		test     func(flags LightFlags) bool
@@ -125,6 +128,7 @@ func TestLightFlags(t *testing.T) {
 }
 
 func TestSwitchIsASwitch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		device interface{}
 	}{
@@ -141,6 +145,7 @@ func TestSwitchIsASwitch(t *testing.T) {
 }
 
 func TestSwitchProcess(t *testing.T) {
+	t.Parallel()
 	downstreamCh := make(chan *Message, 1)
 	recvCh := make(chan *Message, 1)
 	sd := &switchedDevice{downstreamRecvCh: downstreamCh, recvCh: recvCh}
@@ -161,6 +166,7 @@ func TestSwitchProcess(t *testing.T) {
 }
 
 func TestSwitchedDeviceFactory(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		info     DeviceInfo
 		expected interface{}
@@ -187,6 +193,7 @@ func TestSwitchedDeviceFactory(t *testing.T) {
 }
 
 func TestSwitchCommands(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		firmwareVersion FirmwareVersion
 		callback        func(*switchedDevice) error
@@ -232,6 +239,7 @@ func TestSwitchCommands(t *testing.T) {
 }
 
 func TestSwitchedDeviceConfig(t *testing.T) {
+	t.Parallel()
 	sender := &commandable{
 		recvCmd: CmdExtendedGetSet,
 	}
@@ -250,6 +258,7 @@ func TestSwitchedDeviceConfig(t *testing.T) {
 }
 
 func TestSwitchedDeviceOperatingFlags(t *testing.T) {
+	t.Parallel()
 	sender := &commandable{
 		respCmds: []Command{
 			CmdGetOperatingFlags.SubCommand(3),
@@ -271,6 +280,7 @@ func TestSwitchedDeviceOperatingFlags(t *testing.T) {
 }
 
 func TestDimmerIsADimmer(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		device interface{}
 	}{
@@ -287,6 +297,7 @@ func TestDimmerIsADimmer(t *testing.T) {
 }
 
 func TestDimmerProcess(t *testing.T) {
+	t.Parallel()
 	downstreamCh := make(chan *Message, 1)
 	recvCh := make(chan *Message, 1)
 	dd := &dimmableDevice{downstreamRecvCh: downstreamCh, recvCh: recvCh}
@@ -307,6 +318,7 @@ func TestDimmerProcess(t *testing.T) {
 }
 
 func TestDimmerCommands(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		firmwareVersion FirmwareVersion
 		callback        func(*dimmableDevice) error
@@ -353,6 +365,7 @@ func TestDimmerCommands(t *testing.T) {
 }
 
 func TestDimmableDeviceConfig(t *testing.T) {
+	t.Parallel()
 	sender := &commandable{
 		recvCmd: CmdExtendedGetSet,
 	}
@@ -371,6 +384,7 @@ func TestDimmableDeviceConfig(t *testing.T) {
 }
 
 func TestDimmableDeviceFactory(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		info     DeviceInfo
 		expected interface{}

--- a/link_test.go
+++ b/link_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestRecordControlFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input              byte
 		expectedInUse      bool
@@ -60,6 +61,7 @@ func TestRecordControlFlags(t *testing.T) {
 }
 
 func TestRecordControlFlagsUnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input       string
 		expectedErr string
@@ -92,6 +94,7 @@ func TestRecordControlFlagsUnmarshalText(t *testing.T) {
 }
 
 func TestSettingRecordControlFlags(t *testing.T) {
+	t.Parallel()
 	flags := RecordControlFlags(0xff)
 	tests := []struct {
 		desc     string
@@ -115,6 +118,7 @@ func TestSettingRecordControlFlags(t *testing.T) {
 }
 
 func TestLinkEqual(t *testing.T) {
+	t.Parallel()
 	availableController := RecordControlFlags(0x40)
 	availableResponder := RecordControlFlags(0x00)
 	usedController := RecordControlFlags(0xc0)
@@ -155,6 +159,7 @@ func TestLinkEqual(t *testing.T) {
 }
 
 func TestLinkMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc            string
 		input           []byte
@@ -222,6 +227,7 @@ func TestLinkMarshalUnmarshal(t *testing.T) {
 }
 
 func TestLinkRecordMarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		expectedString string
 		expected       LinkRecord
@@ -256,6 +262,7 @@ func TestLinkRecordMarshalText(t *testing.T) {
 }
 
 func TestGroupUnmarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input       string
 		expectedErr string

--- a/link_test.go
+++ b/link_test.go
@@ -36,6 +36,7 @@ func TestRecordControlFlags(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%02x", test.input), func(t *testing.T) {
+			t.Parallel()
 			flags := RecordControlFlags(test.input)
 			if flags.InUse() != test.expectedInUse {
 				t.Errorf("got InUse %v, want %v", flags.InUse(), test.expectedInUse)
@@ -78,6 +79,7 @@ func TestRecordControlFlagsUnmarshalText(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
 			var flags RecordControlFlags
 			err := flags.UnmarshalText([]byte(test.input))
 			if err == nil {
@@ -109,6 +111,7 @@ func TestSettingRecordControlFlags(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			test.set()
 			if byte(flags) != test.expected {
 				t.Errorf("got flags 0x%02x, want 0x%02x", byte(flags), test.expected)
@@ -151,6 +154,7 @@ func TestLinkEqual(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			if test.link1.Equal(test.link2) != test.expected {
 				t.Errorf("got %v, want %v", !test.expected, test.expected)
 			}
@@ -188,6 +192,7 @@ func TestLinkMarshalUnmarshal(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			link := &LinkRecord{}
 			err := link.UnmarshalBinary(test.input)
 			if !isError(err, test.expectedError) {
@@ -239,6 +244,7 @@ func TestLinkRecordMarshalText(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.expectedString, func(t *testing.T) {
+			t.Parallel()
 			if test.expectedErr == "" {
 				buf, _ := test.expected.MarshalText()
 				if !bytes.Equal([]byte(test.expectedString), buf) {
@@ -276,6 +282,7 @@ func TestGroupUnmarshalText(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
 			var group Group
 			err := group.UnmarshalText([]byte(test.input))
 			if err == nil {

--- a/linkdb_test.go
+++ b/linkdb_test.go
@@ -33,6 +33,7 @@ func TestMemAddress(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%04x", test.input), func(t *testing.T) {
+			t.Parallel()
 			addr := MemAddress(test.input)
 			if addr.String() != test.expected {
 				t.Errorf("got %v, want %v", addr.String(), test.expected)
@@ -55,6 +56,7 @@ func TestLinkRequestType(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%02x", test.input), func(t *testing.T) {
+			t.Parallel()
 			lrt := LinkRequestType(test.input)
 			if test.expected != lrt.String() {
 				t.Errorf("got %v, want %v", lrt.String(), test.expected)
@@ -113,6 +115,7 @@ func TestLinkRequest(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			linkRequest := &LinkRequest{}
 			err := linkRequest.UnmarshalBinary(test.input)
 			if !isError(err, test.expectedError) {

--- a/linkdb_test.go
+++ b/linkdb_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestMemAddress(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    int
 		expected string
@@ -41,6 +42,7 @@ func TestMemAddress(t *testing.T) {
 }
 
 func TestLinkRequestType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    byte
 		expected string
@@ -62,6 +64,7 @@ func TestLinkRequestType(t *testing.T) {
 }
 
 func TestLinkRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc            string
 		input           []byte
@@ -144,10 +147,13 @@ func TestLinkRequest(t *testing.T) {
 }
 
 func TestAddLink(t *testing.T) {
+	t.Parallel()
 }
 
 func TestRemoveLink(t *testing.T) {
+	t.Parallel()
 }
 
 func TestCleanup(t *testing.T) {
+	t.Parallel()
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestLogLevel(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		level LogLevel
 		str   string
@@ -44,6 +45,7 @@ func TestLogLevel(t *testing.T) {
 }
 
 func TestLogging(t *testing.T) {
+	t.Parallel()
 	levels := []LogLevel{LevelNone, LevelInfo, LevelDebug}
 	for _, level := range levels {
 		messages := []string{}

--- a/logging_test.go
+++ b/logging_test.go
@@ -37,6 +37,7 @@ func TestLogLevel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("level %q", test.str), func(t *testing.T) {
+			t.Parallel()
 			if test.str != test.level.String() {
 				t.Errorf("got %q, want %q", test.level.String(), test.str)
 			}

--- a/message_test.go
+++ b/message_test.go
@@ -65,6 +65,7 @@ func TestMessageType(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.expectedString, func(t *testing.T) {
+			t.Parallel()
 			if test.input.Direct() != test.expectedDirect {
 				t.Errorf("got Direct %v, want %v", test.input.Direct(), test.expectedDirect)
 			}
@@ -111,6 +112,7 @@ func TestFlags(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.expectedString, func(t *testing.T) {
+			t.Parallel()
 			if test.input.Type() != test.expectedType {
 				t.Errorf("got Type %v, want %v", test.input.Type(), test.expectedType)
 			}
@@ -230,6 +232,7 @@ func TestMessageMarshalUnmarshal(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			message := &Message{}
 			err := message.UnmarshalBinary(test.input)
 			if !isError(err, test.expectedError) {
@@ -293,6 +296,7 @@ func TestChecksum(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			got := checksum(test.input)
 			if got != test.expected {
 				t.Errorf("got checksum %02x, want %02x", got, test.expected)

--- a/message_test.go
+++ b/message_test.go
@@ -46,6 +46,7 @@ var (
 )
 
 func TestMessageType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input             MessageType
 		expectedDirect    bool
@@ -80,6 +81,7 @@ func TestMessageType(t *testing.T) {
 }
 
 func TestFlags(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input            Flags
 		expectedType     MessageType
@@ -137,6 +139,7 @@ func TestFlags(t *testing.T) {
 }
 
 func TestMessageMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc            string
 		input           []byte
@@ -270,6 +273,7 @@ func TestMessageMarshalUnmarshal(t *testing.T) {
 }
 
 func TestChecksum(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc     string
 		input    []byte
@@ -298,6 +302,7 @@ func TestChecksum(t *testing.T) {
 }
 
 func TestCommonTypeConsts(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		want Flags
 		MessageType

--- a/network_test.go
+++ b/network_test.go
@@ -60,6 +60,7 @@ func TestNetworkReceive(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			recvCh := make(chan []byte, 1)
 			testDb := newTestProductDB()
 			connection := make(chan *Message, 1)
@@ -106,6 +107,7 @@ func TestNetworkSendMessage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *PacketRequest, 1)
 			testDb := newTestProductDB()
 			testDb.deviceInfo = test.deviceInfo
@@ -150,6 +152,7 @@ func TestNetworkEngineVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *PacketRequest, 1)
 			recvCh := make(chan []byte, 1)
 			network := New(sendCh, recvCh, time.Millisecond)
@@ -200,6 +203,7 @@ func TestNetworkIDRequest(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *PacketRequest, 1)
 			recvCh := make(chan []byte, 1)
 			network := New(sendCh, recvCh, time.Millisecond)
@@ -272,6 +276,7 @@ func TestNetworkDial(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			testDb := newTestProductDB()
 			network, sendCh, recvCh := newTestNetwork(1)
 			network.DB = testDb

--- a/network_test.go
+++ b/network_test.go
@@ -48,6 +48,7 @@ func newTestNetwork(bufSize int) (*Network, chan *PacketRequest, chan []byte) {
 }*/
 
 func TestNetworkReceive(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc            string
 		input           *Message
@@ -88,6 +89,7 @@ func TestNetworkReceive(t *testing.T) {
 }
 
 func TestNetworkSendMessage(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc       string
 		input      *Message
@@ -133,6 +135,7 @@ func TestNetworkSendMessage(t *testing.T) {
 }
 
 func TestNetworkEngineVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc            string
 		returnedAck     *Message
@@ -180,6 +183,7 @@ func TestNetworkEngineVersion(t *testing.T) {
 }
 
 func TestNetworkIDRequest(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc             string
 		timeout          bool
@@ -247,6 +251,7 @@ func TestNetworkIDRequest(t *testing.T) {
 }
 
 func TestNetworkDial(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc          string
 		deviceInfo    *DeviceInfo
@@ -304,6 +309,7 @@ func TestNetworkDial(t *testing.T) {
 }
 
 func TestNetworkClose(t *testing.T) {
+	t.Parallel()
 	network, _, _ := newTestNetwork(1)
 	network.Close()
 
@@ -319,6 +325,7 @@ func TestNetworkClose(t *testing.T) {
 
 /*
 func TestNetworkConnect(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		deviceInfo    *DeviceInfo
 		engineVersion EngineVersion

--- a/plm/command_test.go
+++ b/plm/command_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestCommand(t *testing.T) {
+	t.Parallel()
 	fs := token.NewFileSet()
 	parsedFile, err := parser.ParseFile(fs, "command.go", nil, parser.ParseComments)
 	if err == nil {

--- a/plm/config_test.go
+++ b/plm/config_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestSettingConfigFlags(t *testing.T) {
+	t.Parallel()
 	config := Config(0x00)
 
 	tests := []struct {
@@ -59,6 +60,7 @@ func TestSettingConfigFlags(t *testing.T) {
 }
 
 func TestConfigString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    byte
 		expected string
@@ -81,6 +83,7 @@ func TestConfigString(t *testing.T) {
 }
 
 func TestConfigMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input byte
 	}{

--- a/plm/config_test.go
+++ b/plm/config_test.go
@@ -38,6 +38,7 @@ func TestSettingConfigFlags(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			if test.getter() {
 				t.Errorf("getter got %v, want false", test.getter())
 			}
@@ -74,6 +75,7 @@ func TestConfigString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.expected, func(t *testing.T) {
+			t.Parallel()
 			config := Config(test.input)
 			if config.String() != test.expected {
 				t.Errorf("got %q, expected %q", config.String(), test.expected)
@@ -103,6 +105,7 @@ func TestConfigMarshalUnmarshal(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("0x%02x", test.input), func(t *testing.T) {
+			t.Parallel()
 			config.UnmarshalBinary([]byte{test.input})
 
 			if byte(config) != test.input {

--- a/plm/connection_test.go
+++ b/plm/connection_test.go
@@ -83,6 +83,7 @@ func TestConnectionReceive(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			sendCh := make(chan *CommandRequest, 1)
 			recvCh := make(chan *Packet, 1)
 			conn := &connection{

--- a/plm/connection_test.go
+++ b/plm/connection_test.go
@@ -43,6 +43,7 @@ func testClosedChannels(sendCh chan *CommandRequest, conn *connection) (string, 
 }
 
 func TestConnectionSend(t *testing.T) {
+	t.Parallel()
 	sendCh := make(chan *CommandRequest, 1)
 	conn := newConnection(sendCh, nil, CmdSendInsteonMsg)
 
@@ -68,6 +69,7 @@ func TestConnectionSend(t *testing.T) {
 }
 
 func TestConnectionReceive(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc     string
 		input    *Packet

--- a/plm/packet_test.go
+++ b/plm/packet_test.go
@@ -37,6 +37,7 @@ func TestPacketAckNak(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("0x%02x 0x%02x", test.cmd, test.input), func(t *testing.T) {
+			t.Parallel()
 			p := &Packet{Command: test.cmd, Ack: test.input}
 			if p.ACK() != test.ack {
 				t.Errorf("got ack %v, want %v ", p.ACK(), test.ack)
@@ -63,6 +64,7 @@ func TestPacketMarshalUnmarshalBinary(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			packet := &Packet{}
 			err := packet.UnmarshalBinary(test.input)
 			if err == test.expectedErr {
@@ -90,6 +92,7 @@ func TestPacketMarshalBinary(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
 			buf, _ := test.input.MarshalBinary()
 			if !bytes.Equal(test.expected, buf) {
 				t.Errorf("got %v, want %v", test.expected, buf)
@@ -110,6 +113,7 @@ func TestPacketString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.expected, func(t *testing.T) {
+			t.Parallel()
 			str := test.input.String()
 			if str != test.expected {
 				t.Errorf("got %q, want %q", str, test.expected)
@@ -137,6 +141,7 @@ func TestPacketFormat(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.expected, func(t *testing.T) {
+			t.Parallel()
 			str := fmt.Sprintf(test.format, test.input)
 			if str != test.expected {
 				t.Errorf("got %q, want %q", str, test.expected)

--- a/plm/packet_test.go
+++ b/plm/packet_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestPacketAckNak(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		cmd   Command
 		input byte
@@ -49,6 +50,7 @@ func TestPacketAckNak(t *testing.T) {
 }
 
 func TestPacketMarshalUnmarshalBinary(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc        string
 		input       []byte
@@ -77,6 +79,7 @@ func TestPacketMarshalUnmarshalBinary(t *testing.T) {
 }
 
 func TestPacketMarshalBinary(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		desc     string
 		input    *Packet
@@ -96,6 +99,7 @@ func TestPacketMarshalBinary(t *testing.T) {
 }
 
 func TestPacketString(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    *Packet
 		expected string
@@ -115,6 +119,7 @@ func TestPacketString(t *testing.T) {
 }
 
 func TestPacketFormat(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		format   string
 		input    *Packet

--- a/plm/plm_test.go
+++ b/plm/plm_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestPlmTimeout(t *testing.T) {
+	t.Parallel()
 	upstreamRecvCh := make(chan []byte, 1)
 	doneCh := make(chan *PacketRequest, 1)
 	request := &PacketRequest{DoneCh: doneCh}
@@ -27,6 +28,7 @@ func TestPlmTimeout(t *testing.T) {
 }
 
 func TestPlmOption(t *testing.T) {
+	t.Parallel()
 	want := 1234 * time.Millisecond
 
 	without := New(&Port{}, 5*time.Second)


### PR DESCRIPTION
use t.Parallel() to speed up test wall :clock10:  by 40-50% (as reported by go test).

But, this is meaningless, because it's going from 8ms to 4.5ms.  Overhead of `go test` environment is ~300ms +/- 20ms on my desktop. 

Fun to try, but I wouldn't blame you at all if you don't merge this. :smile: 

:man_shrugging: 
