### PR TITLE
improve error propagation

### DIFF
--- a/cmd/ic/device.go
+++ b/cmd/ic/device.go
@@ -51,7 +51,8 @@ func (dev *device) init() (err error) {
 }
 
 func connect(plm *plm.PLM, addr insteon.Address) (insteon.Device, error) {
-	device, err := plm.Open(addr)
+	device, err := plm.Open(addr, insteon.ConnectionTimeout(timeoutFlag), insteon.ConnectionTTL(uint8(ttlFlag)))
+
 	if err == insteon.ErrNotLinked {
 		msg := fmt.Sprintf("Device %s is not linked to the PLM.  Link now? (y/n) ", addr)
 		if cli.Query(os.Stdin, os.Stdout, msg, "y", "n") == "y" {

--- a/cmd/ic/main.go
+++ b/cmd/ic/main.go
@@ -56,10 +56,16 @@ func run() error {
 
 	s, err := serial.OpenPort(c)
 
-	if err == nil {
-		modem = plm.New(plm.NewPort(s, timeoutFlag), timeoutFlag, plm.WriteDelay(writeDelayFlag))
+	if err != nil {
+		return fmt.Errorf("error opening serial port: %v", err)
 	}
-	return err
+
+	modem, err = plm.New(plm.NewPort(s, timeoutFlag), timeoutFlag, plm.WriteDelay(writeDelayFlag))
+	if err != nil {
+		return fmt.Errorf("error opening plm: %v", err)
+	}
+
+	return nil
 }
 
 func main() {

--- a/connection.go
+++ b/connection.go
@@ -171,7 +171,7 @@ func (ml *msgListeners) AddListener(t MessageType, cmds ...Command) <-chan *Mess
 // NewConnection will return a connection that is setup and ready to be used.  The txCh and
 // rxCh will be used to send and receive insteon messages.  Any supplied options will be
 // used to customize the connection's config
-func NewConnection(txCh chan<- *Message, rxCh <-chan *Message, addr Address, options ...ConnectionOption) Connection {
+func NewConnection(txCh chan<- *Message, rxCh <-chan *Message, addr Address, options ...ConnectionOption) (Connection, error) {
 	conn := &connection{
 		Mutex:        &sync.Mutex{},
 		msgListeners: &msgListeners{listeners: make(map[<-chan *Message]*msgListener)},
@@ -189,12 +189,12 @@ func NewConnection(txCh chan<- *Message, rxCh <-chan *Message, addr Address, opt
 		err := option(conn)
 		if err != nil {
 			Log.Infof("error setting connection option: %v", err)
-			// TODO: return an error if there's an error
+			return nil, err
 		}
 	}
 
 	go conn.readLoop()
-	return conn
+	return conn, nil
 }
 
 func (conn *connection) Address() Address {

--- a/plm/plm.go
+++ b/plm/plm.go
@@ -188,12 +188,16 @@ func (plm *PLM) send(txPacket *Packet) (ack *Packet, err error) {
 	return plm.tx(txPacket)
 }
 
-func (plm *PLM) Connect(addr insteon.Address, options ...insteon.ConnectionOption) insteon.Connection {
+func (plm *PLM) Connect(addr insteon.Address, options ...insteon.ConnectionOption) (insteon.Connection, error) {
 	return insteon.NewConnection(plm.insteonTxCh, plm.insteonRxCh, addr, options...)
 }
 
 func (plm *PLM) Open(addr insteon.Address, options ...insteon.ConnectionOption) (insteon.Device, error) {
-	conn := plm.Connect(addr, options...)
+	conn, err := plm.Connect(addr, options...)
+	if err != nil {
+		return nil, err
+	}
+
 	return insteon.Open(conn, plm.timeout)
 }
 

--- a/plm/plm.go
+++ b/plm/plm.go
@@ -60,7 +60,7 @@ type PLM struct {
 type Option func(p *PLM) error
 
 // New creates a new PLM instance.
-func New(port *Port, timeout time.Duration, options ...Option) *PLM {
+func New(port *Port, timeout time.Duration, options ...Option) (*PLM, error) {
 	plm := &PLM{
 		timeout:     timeout,
 		writeDelay:  500 * time.Millisecond,
@@ -73,15 +73,14 @@ func New(port *Port, timeout time.Duration, options ...Option) *PLM {
 	for _, o := range options {
 		err := o(plm)
 		if err != nil {
-			insteon.Log.Infof("error setting option %v: %v", err, err)
-			return nil
-			// TODO: change New() to return an error if there's an error
+			insteon.Log.Infof("error setting plm option: %v", err)
+			return nil, err
 		}
 	}
 
 	go plm.readLoop()
 	go plm.writeLoop()
-	return plm
+	return plm, nil
 }
 
 // WriteDelay can be passed as a parameter to New to change the delay used after writing a command before reading the response.

--- a/plm/plm_test.go
+++ b/plm/plm_test.go
@@ -11,12 +11,19 @@ func TestPlmOption(t *testing.T) {
 	want := 1234 * time.Millisecond
 	buf := bytes.NewBuffer(nil)
 
-	without := New(&Port{in: bufio.NewReader(buf), out: buf}, 5*time.Second)
+	without, err := New(&Port{in: bufio.NewReader(buf), out: buf}, 5*time.Second)
+	if err != nil {
+		t.Errorf("unexpected error from plm.New(): %v", err)
+	}
 	if without.writeDelay == want {
 		t.Errorf("writeDelay is %v, expected anything else", without.writeDelay)
 	}
 
-	with := New(&Port{in: bufio.NewReader(buf), out: buf}, 5*time.Second, WriteDelay(want))
+	with, err := New(&Port{in: bufio.NewReader(buf), out: buf}, 5*time.Second, WriteDelay(want))
+	if err != nil {
+		t.Errorf("unexpected error from plm.New(): %v", err)
+	}
+
 	if with.writeDelay != want {
 		t.Errorf("writeDelay is %v, want %v", without.writeDelay, want)
 	}


### PR DESCRIPTION
I noticed that I could set a TTL of 4, and it was happily accepted.  This made no sense, as there's only two bits to hold the ttl.

This set of changes adds error handling to ConnectionOptions, propagates errors up the stack a bit (from places where it wasn't being propagated, and most importantly actually passes the ttl options through in the default case.