### PR TITLE
Configure `go mod` for abates/insteon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/abates/insteon
+
+go 1.12
+
+require (
+	github.com/abates/cli v0.0.0-20190413144006-a1535049783a
+	github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/abates/cli v0.0.0-20190413144006-a1535049783a h1:rtd9lcTMcaypKhjXNjUFKmqiSVmf1HpWe5JmX9HjZbg=
+github.com/abates/cli v0.0.0-20190413144006-a1535049783a/go.mod h1:IbI6wKYxWh1jh6mn/SWJwXvsoYzIzW1aoddwzXKhZWo=
+github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07 h1:UyzmZLoiDWMRywV4DUYb9Fbt8uiOSooupjTq10vpvnU=
+github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Setup go modules (see `go help modules`).  

> A module is a collection of related Go packages.
> Modules are the unit of source code interchange and versioning.
> The go command has direct support for working with modules,
> including recording and resolving dependencies on other modules.
> Modules replace the old GOPATH-based approach to specifying
> which source files are used in a given build.