### PR TITLE
Add Makefile for easy running of tests and coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
   - master
 
 before_install:
+  - go get ${gobuild_args} ./...
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+test:
+	go test ./...
+
+coverage:
+	go test -cover ./... -coverprofile=coverage.out
+
+htmlcoverage: coverage
+	go tool cover -html=coverage.out
+
+funccoverage: coverage
+	go tool cover -func=coverage.out
+
+ic:
+	go build ./cmd/ic
+
+build: ic


### PR DESCRIPTION
Add a Makefile to make it easier to run all the tests and generate and view coverage data.